### PR TITLE
質問の詳細ページの修正

### DIFF
--- a/frontend/src/components/DetailCard.vue
+++ b/frontend/src/components/DetailCard.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-card class="full-screen-card">
+    <MdPreview :editorId="props.editorId" :modelValue="props.content" />
+    <v-card-actions class="d-flex justify-space-between">
+      <div class="d-flex justify-space-between text-end">
+        <p>{{ props.userId }}|</p>
+        <p>{{ props.createdAt ? props.createdAt.toLocaleDateString() : '' }}</p>
+      </div>
+      <div>
+        <v-btn @click="showModal(props.content, isQuestion)">編集</v-btn>
+      </div>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { MdPreview } from 'md-editor-v3'
+
+export interface Props {
+  editorId: string
+  content: string
+  userId: string
+  createdAt: Date | undefined
+  showModal: Function
+  isQuestion: boolean
+}
+
+const props = defineProps<Props>()
+</script>


### PR DESCRIPTION
質問の詳細ページについて，APIでデータを取得するようにしたのと，編集用モーダルの追加などを行いました。
まだ用意していないAPIやログイン情報などが必要な部分についてはコメントを残すなどしています。

1つ質問があるのですが，オブジェクトに対して```reactive```を使うと値をまとめて代入することができなくなってしまうようです。この場合，今回はオブジェクトでも```ref```を使うことにより解決しましたが，それで良いでしょうか。それとも，プロパティをひとつづつ代入するなどしてでも```reactive```を使う方が良いのでしょうか。
何かアドバイスがあればお願いいたします🙏