### PR TITLE
細かい部分の修正と機能追加

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,7 +25,7 @@
 
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, provide } from 'vue'
 import { getMe, type User } from '@/lib/api/users'
 import { BASE } from '@/lib/api/index'
 import { useRouter } from 'vue-router'
@@ -58,6 +58,8 @@ onMounted(async () => {
     console.error(error)
   }
 })
+
+provide('loginUser', loginUser)
 </script>
 
 <style scoped></style>

--- a/frontend/src/components/DetailCard.vue
+++ b/frontend/src/components/DetailCard.vue
@@ -2,11 +2,29 @@
   <v-card class="full-screen-card">
     <MdPreview :editorId="props.editorId" :modelValue="props.content" />
     <v-card-actions class="d-flex justify-space-between">
-      <div class="d-flex justify-space-between text-end">
-        <p>{{ props.userId }}|</p>
-        <p>{{ props.createdAt ? props.createdAt.toLocaleDateString() : '' }}</p>
+      <div class="d-flex">
+        <v-btn :to="`$/users/${props.userId}`">
+          <v-avatar size="small" class="avatar">
+            <div class="mr--1"></div>
+            <v-img
+              :src="user?.icon_url ?? ''"
+              aspect-ratio="1"
+              contain
+              class="avatar-image"
+            ></v-img>
+          </v-avatar>
+          <div style="margin-left: -8px">
+            <v-chip variant="text" color="grey">{{ user?.name }}</v-chip>
+          </div>
+        </v-btn>
+        <div style="margin-top: 3px">
+          <v-chip variant="text" color="grey">
+            {{ diffHuman(props.createdAt ?? new Date()).diff }}</v-chip
+          >
+        </div>
       </div>
-      <div>
+
+      <div v-if="loginUser?.id === props.userId">
         <v-btn @click="showModal(props.content, isQuestion)">編集</v-btn>
       </div>
     </v-card-actions>
@@ -15,7 +33,13 @@
 
 <script setup lang="ts">
 import { MdPreview } from 'md-editor-v3'
+import { diffHuman } from '@/lib/format'
+import { ref, onMounted } from 'vue'
+import { getUser, type User } from '@/lib/api/users'
+import { inject, type Ref } from 'vue'
 
+const loginUser = inject<Ref<User | null>>('loginUser')
+const user = ref<User>()
 export interface Props {
   editorId: string
   content: string
@@ -26,4 +50,14 @@ export interface Props {
 }
 
 const props = defineProps<Props>()
+
+onMounted(async () => {
+  try {
+    const res = await getUser({ id: props.userId }) // 本番
+    // const res = await getUser({ id: 'test-user-0' }) // テスト
+    user.value = res
+  } catch (err) {
+    console.error(err)
+  }
+})
 </script>

--- a/frontend/src/components/QuestionCard.vue
+++ b/frontend/src/components/QuestionCard.vue
@@ -21,7 +21,7 @@
             {{ props.question.answers.length }}件の回答
           </div>
           <div :class="`${$style.status} text-caption`">
-            {{ props.question.userId }}
+            {{ user?.name }}
             <v-tooltip :text="diffHuman(props.question.createdAt).localeString" location="top">
               <template v-slot:activator="{ props: tooltipProps }">
                 <span v-bind="tooltipProps">
@@ -38,6 +38,8 @@
 
 <script setup lang="ts">
 import { diffHuman } from '@/lib/format'
+import { ref, onMounted } from 'vue'
+import { getUser, type User } from '@/lib/api/users'
 import QuestionTag from './QuestionTag.vue'
 import QuestionStatus from './QuestionStatus.vue'
 import type { Question } from '@/lib/api/questions'
@@ -46,6 +48,17 @@ export interface Props {
   question: Question
 }
 const props = defineProps<Props>()
+
+const user = ref<User>()
+
+onMounted(async () => {
+  try {
+    const res = await getUser({ id: props.question.userId })
+    user.value = res
+  } catch (err) {
+    console.error(err)
+  }
+})
 </script>
 
 <style module>

--- a/frontend/src/views/CreateQuestionView.vue
+++ b/frontend/src/views/CreateQuestionView.vue
@@ -94,7 +94,8 @@
 <script setup lang="ts">
 import { MdEditor } from 'md-editor-v3'
 import 'md-editor-v3/lib/style.css'
-import { ref, computed, reactive } from 'vue'
+import { ref, computed, reactive, inject, type Ref } from 'vue'
+import { type User } from '@/lib/api/users'
 import { postQuestion } from '@/lib/api/questions'
 import { getTags, postTag, type Tag } from '@/lib/api/tags'
 import { useRouter } from 'vue-router'
@@ -109,6 +110,7 @@ const form = reactive<{ title: string; content: string; tags: Tag[] }>({
 })
 const tags = await getTags()
 const router = useRouter()
+const loginUser = inject<Ref<User | null>>('loginUser')
 
 const canPostQuestion = computed(() => {
   return form.title.length > 0 && form.content.length > 0
@@ -131,7 +133,7 @@ const postNewQuestion = async () => {
   const selectedTagIds: Omit<Tag, 'name'>[] = form.tags.map((tag) => ({ id: tag.id }))
   try {
     const res = await postQuestion({
-      userId: 'masky', //TODO： ログインユーザーのIDを取得する
+      userId: loginUser?.userId,
       title: form.title,
       content: form.content,
       tags: selectedTagIds,

--- a/frontend/src/views/QuestionDetailView.vue
+++ b/frontend/src/views/QuestionDetailView.vue
@@ -10,7 +10,7 @@
       </div>
       <div class="text-end">
         <v-chip variant="text" color="grey">{{ user?.name }}</v-chip>
-        ><v-chip variant="text" color="grey"
+        <v-chip variant="text" color="grey"
           >投稿日:{{ question.createdAt ? question.createdAt.toLocaleDateString() : '' }}</v-chip
         >
       </div>


### PR DESCRIPTION
- 質問カードでユーザーIDが表示されていたのをユーザーネームにした+詳細ページではiconも表示してユーザーページで飛べるようにした
- 編集ボタンがログインユーザーと一致してないと表示されないようにした
- 質問投稿ページのuserIdをログインユーザーのIdにした

本当は質問の編集のAPIもやりたかったんですが，mockの扱いなどでつまづいてしまったので一旦諦めました:pray:

一番上の変更については，質問+その回答の回数だけAPIを叩くことになってしまうので，やはり微妙でしょうか。