### PR TITLE
Statuses が空だとエラーが出るので修正

### DIFF
--- a/handler/imggen.go
+++ b/handler/imggen.go
@@ -38,7 +38,7 @@ func (h *Handler) PostImage(c echo.Context) error {
 	questions, _, err := h.qrepo.FindByUserID(request.UserID, &repository.FindQuestionsCondition{
 		Limit:    46,
 		Offset:   0,
-		Statuses: []domain.QuestionStatus{domain.QuestionStatusOpen, domain.QuestionStatusClosed},
+		Statuses: domain.AvailableQuestionStatus(),
 	})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/handler/imggen.go
+++ b/handler/imggen.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/labstack/echo/v4"
+	"github.com/traP-jp/h23w_10/pkg/domain"
 	"github.com/traP-jp/h23w_10/pkg/domain/repository"
 	"golang.org/x/sync/errgroup"
 )
@@ -35,8 +36,9 @@ func (h *Handler) PostImage(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	questions, _, err := h.qrepo.FindByUserID(request.UserID, &repository.FindQuestionsCondition{
-		Limit:  46,
-		Offset: 0,
+		Limit:    46,
+		Offset:   0,
+		Statuses: []domain.QuestionStatus{domain.QuestionStatusOpen, domain.QuestionStatusClosed},
 	})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
/api/imggen を叩いたら `empty slice passed to 'in' query` が返ってきた
Statuses を渡したら直った